### PR TITLE
IE6-9 compatibility issues with admin panel, minor IE padding / margin edits

### DIFF
--- a/app.yml
+++ b/app.yml
@@ -1,4 +1,4 @@
-application: timoun-production
+application: timoun-staging
 version: 1
 runtime: python27
 api_version: 1

--- a/assets/css/min-styles.css
+++ b/assets/css/min-styles.css
@@ -162,8 +162,8 @@ message {
 
 .search-map {width: 40%!important; float: left!important; height: 400px!important; margin: 0; padding: 0;}
 .results-box {background:#fff; width: 39%; margin-top: -3px; margin-left: 1%; padding: 0; border: 3px solid #302e2c; height: 400px; overflow: scroll; float: left;}
-.result {width: 80%; margin-left: 10%; padding: 10px 0 10px 0; border-bottom: 1px solid #999;}
-.result p {color:#258db1; margin:0; padding-bottom: 5px;}
+.result {width: 90%; padding: 10px 0 10px 0; border-bottom: 1px solid #999;}
+.result p {color:#258db1!important; text-align: left; width: 100%!important; margin:0; padding-bottom: 5px;}
 ul.pagination {float: left;list-style-type: none; padding: 0; margin: 25px 0 25px 0; width: 100%;}
 ul.pagination li {display: inline; background: #f9c700; padding: 5px 10px 5px 10px;}
 ul.pagination li a {color: #333;}

--- a/templates/layouts/fr_legacy_admin.html
+++ b/templates/layouts/fr_legacy_admin.html
@@ -25,6 +25,12 @@
       <script src="assets/js/responsive-nav.js"></script>
       <script src="../assets/js/responsive-nav.js"></script>
       <script src="../../assets/js/responsive-nav.js"></script>
+
+      <!--[if lte IE 9]>
+              <style>
+                .main {margin-left: 325px; width: auto;}
+              </style>
+      <![endif]-->
       
       <!--[if IE 8]>
               <style>

--- a/templates/layouts/fr_legacy_base.html
+++ b/templates/layouts/fr_legacy_base.html
@@ -32,6 +32,12 @@
       <style>
           .alert_message {color: #f36813; text-align: center; font-size: 1.2em;}
       </style>
+
+      <!--[if lte IE 9]>
+              <style>
+                .bottom {padding-bottom: 5px;}
+              </style>
+      <![endif]-->
       
        <!--[if IE 8]>
       <script src="respond.js"></script>
@@ -185,7 +191,7 @@
                     <li><a href="/users/login">S'identifier</a></li>
                     {% endif %}
                 </ul>
-                <p class="copy" style="padding:0;">Supporté par  <a href="http://www.crs.org/"><img src="../../assets/img/catholic-relief-services-logo-white-100.png" width="60" height="" /></a></p>
+                <p class="copy" style="padding:0;">Supporté par  <a href="http://www.crs.org/"><img src="../../assets/img/catholic-relief-services-logo-white-100.png" width="60" height="33" /></a></p>
                 <p class="copy">&copy;2015 <a href="http://ibesr.com/" target="_blank" rel="nofollow">IBESR: Institut du Bien-Etre Social et de Recherches</a>. Tous Les Droits Sont Réservés.</p>
             </div>
     <script>

--- a/templates/layouts/legacy_admin.html
+++ b/templates/layouts/legacy_admin.html
@@ -27,6 +27,12 @@
       <script src="../assets/js/responsive-nav.js"></script>
       <script src="../../assets/js/responsive-nav.js"></script>
       
+      <!--[if lte IE 9]>
+              <style>
+                .main {margin-left: 325px; width: auto;}
+              </style>
+      <![endif]-->
+      
       <!--[if IE 8]>
               <style>
                       .col { margin: 0 0.9% !important; }

--- a/templates/layouts/legacy_base.html
+++ b/templates/layouts/legacy_base.html
@@ -33,6 +33,12 @@
           .alert_message {color: #f36813; text-align: center; font-size: 1.2em;}
       </style>
 
+      <!--[if lte IE 9]>
+              <style>
+                .bottom {padding-bottom: 5px;}
+              </style>
+      <![endif]-->
+      
       <!--[if IE 8]>
       <script src="respond.js"></script>
               <style>
@@ -186,7 +192,7 @@
                     <li><a href="/users/login">Login</a></li>
                     {% endif %}
                 </ul>
-                <p class="copy" style="padding:0;">Supported by   <a href="http://www.crs.org/"><img src="../../assets/img/catholic-relief-services-logo-white-100.png" width="60" height="" /></a></p>
+                <p class="copy" style="padding:0;">Supported by   <a href="http://www.crs.org/"><img src="../../assets/img/catholic-relief-services-logo-white-100.png" width="60" height="33" /></a></p>
                 <p class="copy">&copy;2015 <a href="http://ibesr.com/" target="_blank" rel="nofollow">IBESR: Institut du Bien-Etre Social et de Recherches</a>. All Rights Reserved.</p>
             </div>
     <script>

--- a/templates/static_pages/en_suggest_services.html
+++ b/templates/static_pages/en_suggest_services.html
@@ -142,19 +142,6 @@
           <textarea name="details" cols=40 rows=6></textarea>
         </td>
       </tr>
-
-      <tr>
-        <td><label for="day">Day</label></td>
-          <td>
-            <input type="checkbox" name="monday" value="Monday">M
-            <input type="checkbox" name="tuesday" value="Tuesday">T
-            <input type="checkbox" name="wednesday" value="Wednesday">W
-            <input type="checkbox" name="thursday" value="Thursday">R
-            <input type="checkbox" name="friday" value="Friday">F
-            <input type="checkbox" name="saturday" value="Saturday">Sa
-            <input type="checkbox" name="sunday" value="Sunday">Su
-          </td>
-      </tr>
     </table>
     <br/>
     <input type=submit value=Submit id="submit">

--- a/templates/static_pages/fr_suggest_services.html
+++ b/templates/static_pages/fr_suggest_services.html
@@ -144,19 +144,6 @@
           <textarea name="details" cols=40 rows=6></textarea>
         </td>
       </tr>
-      <tr>
-
-        <td><label for="day">Jour</label></td>
-          <td>
-            <input type="checkbox" name="monday" value="Monday">L
-            <input type="checkbox" name="tuesday" value="Tuesday">Ma
-            <input type="checkbox" name="wednesday" value="Wednesday">Me
-            <input type="checkbox" name="thursday" value="Thursday">J
-            <input type="checkbox" name="friday" value="Friday">V
-            <input type="checkbox" name="saturday" value="Saturday">S
-            <input type="checkbox" name="sunday" value="Sunday">D
-          </td>
-      </tr>
     </table>
     <br/>
     <input type=submit value="Soumettre" id="submit">


### PR DESCRIPTION
Here is the final MVP for Timoun with backwards compatibility going back to IE6. 

This push includes fixes to admin panel block elements (particularly .main). IE wasn't rendering the positioning of the navigation and .main container properly.
